### PR TITLE
Generate lib/colors.ts from colors.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 .sass-cache
+node_modules
+package-lock.json
+
+# generated files
+lib.js
+lib.d.ts
+src/*.ts
+src/*.js
+src/*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,7 @@
 !_kaizen-ui-colors.scss
 !kaizen-ui-colors.json
 !index.js
+!lib.js
+!lib.d.ts
+!src/**/*.js
+!src/**/*.d.ts

--- a/README.md
+++ b/README.md
@@ -56,3 +56,19 @@ var json = require('kaizen-ui-colors');
 ```javascript
 import json from 'kaizen-ui-colors';
 ```
+
+## Use as TypeScript Library
+
+`kaizen-ui-colors/lib` is an entry point which provides color schemas as TypeScript library.
+
+### colors
+
+`colors` module is a **typed** and **camelCased** color schema.
+
+You can import it and use as below:
+
+```ts
+import { colors } from 'kaizen-ui-colors/lib';
+
+console.log(colors.lavaLighter);
+```

--- a/lib.ts
+++ b/lib.ts
@@ -1,0 +1,1 @@
+export * from './src/colors';

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   ],
   "main": "index.js",
   "scripts": {
+    "generate:ts": "node scripts/generate.js && tsc",
+    "preversion": "npm run generate:ts",
     "compile": "./scripts/convert.sh && open preview/index.html"
   },
   "dependencies": {},
@@ -33,5 +35,9 @@
   "bugs": {
     "url": "https://github.com/kaizenplatform/kaizen-ui-colors/issues"
   },
-  "homepage": "https://github.com/kaizenplatform/kaizen-ui-colors#readme"
+  "homepage": "https://github.com/kaizenplatform/kaizen-ui-colors#readme",
+  "devDependencies": {
+    "camelcase": "^4.1.0",
+    "typescript": "^2.4.2"
+  }
 }

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const camelcase = require('camelcase');
+
+const getColorsJSON = () => {
+  return JSON.parse(
+    fs.readFileSync(
+      path.resolve(__dirname, '../kaizen-ui-colors.json'),
+      'utf-8'
+    )
+  );
+};
+
+const generateColors = (colorsJSON, outPath) => {
+  const formatted = Object.keys(colorsJSON.nameToHex).reduce((map, key) => {
+    const colorName = camelcase(key.replace('color-', ''));
+    map[colorName] = colorsJSON.nameToHex[key];
+    return map;
+  }, {});
+  fs.writeFileSync(
+    outPath,
+    '// DO NOT EDIT! This code is generated automatically.\n' +
+      `export const colors = ${JSON.stringify(formatted, null, 2)};`,
+    'utf-8'
+  );
+};
+
+const outPath = path.resolve(__dirname, '../src/colors.ts');
+const colorsJSON = getColorsJSON();
+console.log(`Generating colors.ts in "${outPath}" ...`);
+generateColors(colorsJSON, path.resolve(__dirname, '../src/colors.ts'));
+
+console.log(`Done!`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "outDir": ".",
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "declaration": true
+  },
+  "files": ["lib.ts"]
+}


### PR DESCRIPTION
- colors.jsonのnameToHexだけを取り出して、camelCase化してsrc/colors.tsを生成
- ルートにlib.tsを追加し、src/colors.tsをexport
- tscでコンパイルして、.jsと.d.tsをpublish

index.jsには手を入れていないので、既存のユースケースは壊れないはず。